### PR TITLE
Implement Flow Manager routers and add integration tests

### DIFF
--- a/flow-manager/flow_manager/api/__init__.py
+++ b/flow-manager/flow_manager/api/__init__.py
@@ -1,1 +1,15 @@
 """API routers for Flow Manager."""
+
+from __future__ import annotations
+
+from .events import router as events_router
+from .internal import router as internal_router
+from .peer import router as peer_router
+from .debug import router as debug_router
+
+__all__ = [
+    "events_router",
+    "internal_router",
+    "peer_router",
+    "debug_router",
+]

--- a/flow-manager/flow_manager/api/debug.py
+++ b/flow-manager/flow_manager/api/debug.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+from pydantic import BaseModel
+
+router = APIRouter()
+
+
+class DebugResponse(BaseModel):
+    jwt: dict | None
+    client_cert_cn: str
+
+
+@router.get("/authz/debug", response_model=DebugResponse)
+async def debug(request: Request) -> DebugResponse:
+    return DebugResponse(
+        jwt=getattr(request.state, "jwt_payload", None),
+        client_cert_cn=getattr(request.state, "client_cert_cn", "n/a"),
+    )

--- a/flow-manager/flow_manager/api/events.py
+++ b/flow-manager/flow_manager/api/events.py
@@ -1,22 +1,81 @@
 """Event ingestion endpoints."""
+
 from __future__ import annotations
 
 from fastapi import APIRouter, Request
+from pydantic import BaseModel
 
-from ..modules.topology import process_topology
-from ..etcd.client import SecureETCDClient
+from ..modules import policy, installer, topology
 
-router = APIRouter(prefix="/flowmanager")
-
-
-@router.post("/topology_update")
-async def topology_update(req: Request) -> dict[str, str]:
-    data = await req.json()
-    client = SecureETCDClient(req.app.state.etcd, req.app.state.settings)
-    process_topology(data, client)
-    return {"status": "ok"}
+router = APIRouter()
 
 
-@router.post("/packetin")
-async def packet_in() -> dict[str, str]:
-    return {"status": "queued"}
+class HostModel(BaseModel):
+    ip: str
+    mac: str
+    dpid: str | None = None
+    port: int | None = None
+
+
+class SwitchModel(BaseModel):
+    dpid: str
+    name: str | None = None
+
+
+class TopologyEvent(BaseModel):
+    hosts: list[HostModel]
+    switches: list[SwitchModel]
+
+
+class ResultResponse(BaseModel):
+    result: str
+
+
+class DecisionResponse(BaseModel):
+    decision: str
+
+
+@router.post(
+    "/flowmanager/topology_update",
+    status_code=202,
+    response_model=ResultResponse,
+)
+async def topology_update(event: TopologyEvent, request: Request) -> ResultResponse:
+    await topology.process_topology(request.app, event.dict())
+    return ResultResponse(result="queued")
+
+
+class PacketInEvent(BaseModel):
+    src_ip: str
+    dst_ip: str
+    in_port: int
+    dpid: str
+    proto: str | None = None
+    vlan: int | None = None
+
+
+@router.post(
+    "/flowmanager/packetin",
+    status_code=202,
+    response_model=DecisionResponse,
+)
+async def packet_in(event: PacketInEvent, request: Request) -> DecisionResponse:
+    etcd = request.app.state.etcd
+    decision = policy.decide(
+        etcd,
+        src_ip=event.src_ip,
+        dst_ip=event.dst_ip,
+        proto=event.proto,
+        vlan=event.vlan,
+    )
+    match = {"ipv4_src": event.src_ip, "ipv4_dst": event.dst_ip}
+    if event.vlan is not None:
+        match["vlan_vid"] = event.vlan
+    if event.proto is not None:
+        match["ip_proto"] = event.proto
+    if decision == "allow":
+        flow_id = await installer.add_forward_rule(event.dpid, event.in_port, 1, match)
+    else:
+        flow_id = await installer.add_drop_rule(event.dpid, match)
+    etcd.put_flow(flow_id, {"switch": event.dpid, "decision": decision})
+    return DecisionResponse(decision=decision)

--- a/flow-manager/flow_manager/api/internal.py
+++ b/flow-manager/flow_manager/api/internal.py
@@ -2,27 +2,82 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Request, HTTPException
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, Field
 
-from ..modules.policy import decide
-from ..modules.installer import add_forward_rule
+from ..grpc import FlowRequest
+from ..modules import installer, peer, policy
 
 router = APIRouter()
 
 
-@router.post("/flows")
-async def create_flow(req: Request) -> dict[str, str]:
-    data = await req.json()
+class FlowRequestBody(BaseModel):
+    src_ip: str = Field(..., alias="src_ip")
+    dst_ip: str = Field(..., alias="dst_ip")
+    proto: str | None = None
+    src_port: int | None = None
+    dst_port: int | None = None
+    vlan: int | None = None
+    action: str
+    switch: str
+    in_port: int
+
+
+class FlowCreateResponse(BaseModel):
+    flow_id: str
+
+
+class ResultResponse(BaseModel):
+    result: str
+
+
+@router.post("/flows", status_code=202, response_model=FlowCreateResponse)
+async def create_flow(body: FlowRequestBody, request: Request) -> FlowCreateResponse:
+    etcd = request.app.state.etcd
+    decision = policy.decide(
+        etcd,
+        src_ip=body.src_ip,
+        dst_ip=body.dst_ip,
+        proto=body.proto,
+        vlan=body.vlan,
+    )
+    if decision != body.action:
+        raise HTTPException(status_code=409, detail="policy mismatch")
+    match = {"ipv4_src": body.src_ip, "ipv4_dst": body.dst_ip}
+    if body.vlan is not None:
+        match["vlan_vid"] = body.vlan
+    if body.proto is not None:
+        match["ip_proto"] = body.proto
+    if body.action == "allow":
+        flow_id = await installer.add_forward_rule(body.switch, body.in_port, 1, match)
+    else:
+        flow_id = await installer.add_drop_rule(body.switch, match)
+    record = body.model_dump() | {"remote": False, "switch": body.switch}
+    dest_host = etcd.get(f"/hosts/{body.dst_ip}")
     if (
-        decide(
-            req.app.state.etcd,
-            src_ip=data.get("src_ip", "0.0.0.0"),
-            dst_ip=data.get("dst_ip", "0.0.0.0"),
-            proto=data.get("proto"),
-            vlan=data.get("vlan"),
-        )
-        == "block"
+        dest_host
+        and dest_host.get("domain")
+        and dest_host["domain"] != request.app.state.settings.domain_id
     ):
-        raise HTTPException(status_code=403, detail="blocked")
-    await add_forward_rule("dpid", 1, 2, data)
-    return {"status": "installed"}
+        domain_id = int(dest_host["domain"])
+        await peer.install_flow_remote(
+            domain_id, FlowRequest(id=flow_id, switch=body.switch)
+        )
+        record["remote"] = True
+        record["remote_domain"] = domain_id
+    etcd.put_flow(flow_id, record)
+    return FlowCreateResponse(flow_id=flow_id)
+
+
+@router.delete("/flows/{flow_id}", status_code=202, response_model=ResultResponse)
+async def delete_flow(flow_id: str, request: Request) -> ResultResponse:
+    etcd = request.app.state.etcd
+    record = etcd.get(f"/flows/{flow_id}") or {}
+    await installer.delete_rule(flow_id)
+    if record.get("remote_domain"):
+        await peer.delete_flow_remote(
+            int(record["remote_domain"]),
+            FlowRequest(id=flow_id, switch=str(record.get("switch", ""))),
+        )
+    etcd.delete(f"/flows/{flow_id}")
+    return ResultResponse(result="deleted")

--- a/flow-manager/flow_manager/api/peer.py
+++ b/flow-manager/flow_manager/api/peer.py
@@ -1,11 +1,28 @@
-"""Peer gateway API (placeholder)."""
+"""Peer gateway API."""
+
 from __future__ import annotations
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel
+
+from ..grpc import FlowAck, FlowRequest
+from ..modules import peer
 
 router = APIRouter()
 
 
-@router.post("/flows")
-async def peer_flow() -> dict[str, str]:
-    return {"status": "peer"}
+class FlowRequestModel(BaseModel):
+    id: str
+    switch: str
+    target_domain: int | None = None
+
+
+@router.post("/peer/v1/flows", status_code=202, response_model=FlowAck)
+async def peer_flow(
+    body: FlowRequestModel, target_domain: int | None = Query(None)
+) -> FlowAck:
+    domain = target_domain if target_domain is not None else body.target_domain
+    if domain is None:
+        raise HTTPException(status_code=400, detail="target domain required")
+    req = FlowRequest(id=body.id, switch=body.switch)
+    return await peer.install_flow_remote(domain, req)

--- a/flow-manager/flow_manager/app.py
+++ b/flow-manager/flow_manager/app.py
@@ -1,4 +1,5 @@
 """FastAPI application factory for Flow Manager."""
+
 from __future__ import annotations
 
 from fastapi import FastAPI
@@ -6,7 +7,7 @@ from fastapi import FastAPI
 from .config import Settings
 from .rate_limit import RateLimiterMiddleware
 from .security.jwt_middleware import JWTMiddleware
-from .api import internal, events, peer
+from .api import internal, events, peer, debug
 
 
 def create_app() -> FastAPI:
@@ -17,9 +18,10 @@ def create_app() -> FastAPI:
     app.add_middleware(JWTMiddleware)
     app.add_middleware(RateLimiterMiddleware)
 
-    app.include_router(internal.router, prefix="/api/v1")
-    app.include_router(events.router)
-    app.include_router(peer.router, prefix="/peer/v1")
+    app.include_router(events.router, tags=["events"])
+    app.include_router(internal.router, prefix="/api/v1", tags=["control"])
+    app.include_router(peer.router, tags=["peer"])
+    app.include_router(debug.router, tags=["debug"])
 
     @app.get("/healthz")
     async def healthz() -> dict[str, str]:

--- a/flow-manager/flow_manager/modules/peer.py
+++ b/flow-manager/flow_manager/modules/peer.py
@@ -65,3 +65,14 @@ async def install_flow_remote(domain_id: int, request: FlowRequest) -> FlowAck:
         return await stub.InstallFlow(
             request, metadata={"authorization": f"Bearer {token}"}
         )
+
+
+async def delete_flow_remote(domain_id: int, request: FlowRequest) -> FlowAck:
+    host = f"fm-{domain_id}"
+    ssl = load_ssl_context("cert.pem", "key.pem", "ca.pem")
+    async with Channel(host, 8443, ssl=ssl) as channel:
+        stub = FlowServiceStub(channel)
+        token = _encode_jwt({"scope": "flows:write"})
+        return await stub.DeleteFlow(
+            request, metadata={"authorization": f"Bearer {token}"}
+        )

--- a/tests/test_integration_local_block.py
+++ b/tests/test_integration_local_block.py
@@ -1,0 +1,75 @@
+import os
+import sys
+import asyncio
+
+import httpx
+import pytest
+
+base = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(base, "flow-manager"))  # noqa: E402
+sys.path.insert(0, base)  # noqa: E402
+sys.modules.pop("flow_manager", None)
+
+from etcd3mock import Etcd3Client  # noqa: E402
+from flow_manager.app import create_app  # noqa: E402
+from flow_manager.config import Settings  # noqa: E402
+from flow_manager.etcd.client import SecureETCDClient  # noqa: E402
+from flow_manager.modules import installer  # noqa: E402
+import flow_manager.security.jwt_middleware as jwt_middleware  # noqa: E402
+
+
+def test_local_block(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _run() -> None:
+        settings = Settings()
+        settings.ryu_rest = "http://ryu"
+        etcd = SecureETCDClient(Etcd3Client(), settings)
+        etcd.put_host("10.0.0.1", {"mac": "aa:aa:aa:aa:aa:aa", "dpid": "s1", "port": 1})
+        etcd.put_host("10.0.0.8", {"mac": "bb:bb:bb:bb:bb:bb", "dpid": "s1", "port": 8})
+
+        monkeypatch.setattr(
+            jwt_middleware.PyJWKClient,
+            "get_signing_key_from_jwt",
+            lambda *a, **k: type("K", (), {"key": "secret"})(),
+        )
+        monkeypatch.setattr(
+            jwt_middleware,
+            "jwt",
+            type("J", (), {"decode": lambda *a, **k: {"scope": "flows:write"}})(),
+        )
+
+        requests: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            requests.append(request)
+            return httpx.Response(200, json={})
+
+        installer._CLIENT = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        installer.settings.ryu_rest = "http://ryu"
+
+        app = create_app()
+        app.state.etcd = etcd
+
+        async with httpx.AsyncClient(app=app, base_url="http://test") as client:
+            token = "a.b.c"
+            body = {
+                "src_ip": "10.0.0.1",
+                "dst_ip": "10.0.0.8",
+                "action": "block",
+                "switch": "s1",
+                "in_port": 1,
+            }
+            resp = await client.post(
+                "/api/v1/flows",
+                json=body,
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            assert resp.status_code == 202
+            flow_id = resp.json()["flow_id"]
+
+        assert requests
+        data = requests[0].json()
+        assert data.get("actions") == []
+        key = f"/domain/{settings.domain_id}/flows/{flow_id}"
+        assert key in etcd.client.store
+
+    asyncio.run(_run())

--- a/tests/test_integration_packetin.py
+++ b/tests/test_integration_packetin.py
@@ -1,0 +1,75 @@
+import os
+import sys
+import asyncio
+
+import httpx
+import pytest
+
+base = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(base, "flow-manager"))  # noqa: E402
+sys.path.insert(0, base)  # noqa: E402
+sys.modules.pop("flow_manager", None)
+
+from etcd3mock import Etcd3Client  # noqa: E402
+from flow_manager.app import create_app  # noqa: E402
+from flow_manager.config import Settings  # noqa: E402
+from flow_manager.etcd.client import SecureETCDClient  # noqa: E402
+from flow_manager.modules import installer  # noqa: E402
+import flow_manager.security.jwt_middleware as jwt_middleware  # noqa: E402
+
+
+def test_packetin(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _run() -> None:
+        settings = Settings()
+        settings.ryu_rest = "http://ryu"
+        etcd = SecureETCDClient(Etcd3Client(), settings)
+
+        async def fake_key(_: object, __: str) -> object:
+            class K:
+                key = "secret"
+
+            return K()
+
+        monkeypatch.setattr(
+            jwt_middleware.PyJWKClient,
+            "get_signing_key_from_jwt",
+            fake_key,
+        )
+        monkeypatch.setattr(
+            jwt_middleware,
+            "jwt",
+            type("J", (), {"decode": lambda *a, **k: {"scope": "packetin:write"}})(),
+        )
+
+        requests: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            requests.append(request)
+            return httpx.Response(200, json={})
+
+        installer._CLIENT = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        installer.settings.ryu_rest = "http://ryu"
+
+        app = create_app()
+        app.state.etcd = etcd
+
+        async with httpx.AsyncClient(app=app, base_url="http://test") as client:
+            token = "a.b.c"
+            payload = {
+                "src_ip": "10.0.0.1",
+                "dst_ip": "10.0.0.2",
+                "in_port": 1,
+                "dpid": "1",
+            }
+            resp = await client.post(
+                "/flowmanager/packetin",
+                json=payload,
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            assert resp.status_code == 202
+            assert resp.json()["decision"] in {"allow", "block"}
+
+        assert requests
+        assert requests[0].url.path.endswith("/stats/flowentry/add")
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- add event processing and debug endpoints
- implement flow management REST routes and peer API
- register new routers in FastAPI app
- extend peer module with remote delete helper
- introduce integration tests for packet-in handling and local block flows

## Testing
- `ruff check flow-manager/flow_manager/api flow-manager/flow_manager/app.py tests/test_integration_packetin.py tests/test_integration_local_block.py flow-manager/flow_manager/modules/peer.py`
- `black --check flow-manager/flow_manager/api/*.py flow-manager/flow_manager/app.py flow-manager/flow_manager/modules/peer.py tests/test_integration_packetin.py tests/test_integration_local_block.py`
- `mypy --strict --ignore-missing-imports flow-manager/flow_manager/api/debug.py flow-manager/flow_manager/api/events.py flow-manager/flow_manager/api/internal.py flow-manager/flow_manager/api/peer.py flow-manager/flow_manager/modules/peer.py` *(fails: see log)*
- `pytest -q` *(fails: AsyncClient missing 'app' parameter)*

------
https://chatgpt.com/codex/tasks/task_e_68752fb7a7448330aa11590c88f75f85